### PR TITLE
Fix Node sending a Date header

### DIFF
--- a/nodejs/server.js
+++ b/nodejs/server.js
@@ -2,7 +2,6 @@ const http = require('http');
 
 const srv = http.createServer( (req, res) => {
   let data, status;
-  res.sendDate = false;
   if(req.url === '/') {
     data = 'Hello world!';
     status = 200;


### PR DESCRIPTION
An HTTP server should always send a `Date` header. Aerys does it automatically as well.